### PR TITLE
Bookstore: connect to API

### DIFF
--- a/API_ID.txt
+++ b/API_ID.txt
@@ -1,0 +1,2 @@
+EX3aIl0JC1THeB5FhpPz
+uYBWkn6JQUP0zZxaMqGp

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.3.0",
         "@testing-library/user-event": "^13.5.0",
+        "axios": "^0.27.2",
         "eslint-config-airbnb": "^19.0.4",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
@@ -20,6 +21,7 @@
         "react-router-dom": "^6.3.0",
         "react-scripts": "5.0.1",
         "redux": "^4.2.0",
+        "redux-thunk": "^2.4.1",
         "web-vitals": "^2.1.4"
       }
     },
@@ -4834,6 +4836,28 @@
       "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -20259,6 +20283,27 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.3.tgz",
       "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w=="
+    },
+    "axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "requires": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "axobject-query": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^0.27.2",
     "eslint-config-airbnb": "^19.0.4",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
@@ -15,6 +16,7 @@
     "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",
     "redux": "^4.2.0",
+    "redux-thunk": "^2.4.1",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/components/BookForm.js
+++ b/src/components/BookForm.js
@@ -1,12 +1,15 @@
 import { useState, React } from 'react';
 import { useDispatch } from 'react-redux';
 import { nanoid } from '@reduxjs/toolkit';
-import { createBook } from '../redux/books/book';
+import { addNewBookApi } from '../redux/books/book';
 
 function Form() {
   const [titleInput, setTitleInput] = useState('');
   const [authorInput, setAuthorInput] = useState('');
   const dispatch = useDispatch();
+  const id = nanoid();
+  const category = 'Fiction';
+
   return (
     <div className="form-container">
       <h3>Add new book</h3>
@@ -28,16 +31,23 @@ function Form() {
         <button
           onClick={(e) => {
             e.preventDefault();
-            if (titleInput === '' && authorInput === '') {
+            if (titleInput === '' || authorInput === '') {
               return;
             }
-            dispatch(createBook({ title: titleInput, author: authorInput, id: nanoid() }));
+            dispatch(
+              addNewBookApi({
+                title: titleInput,
+                author: authorInput,
+                id,
+                category,
+              }),
+            );
             setTitleInput('');
             setAuthorInput('');
           }}
           type="submit"
         >
-          Add New Book
+          Add Book
         </button>
       </form>
     </div>

--- a/src/components/BookItem.js
+++ b/src/components/BookItem.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
-import { removeBook } from '../redux/books/book';
+import { removeBookFromApi } from '../redux/books/book';
 import './BookItem.css';
 
 function Book(props) {
   const { id, title, author } = props;
   const dispatch = useDispatch();
+
   return (
     <li className="book-wrapper" id={id}>
       <span className="title">{title}</span>
@@ -14,7 +15,7 @@ function Book(props) {
       <button
         className="del-button"
         onClick={() => {
-          dispatch(removeBook({ id }));
+          dispatch(removeBookFromApi({ id }));
         }}
         type="button"
       >

--- a/src/components/BookList.js
+++ b/src/components/BookList.js
@@ -1,9 +1,15 @@
-import React from 'react';
-import { useSelector } from 'react-redux';
+import React, { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import BookItem from './BookItem';
+import { getBooksToDisplayApi } from '../redux/books/book';
 
 export default function BookList() {
   const booklist = useSelector((state) => state.books);
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(getBooksToDisplayApi(booklist));
+  }, [dispatch]);
 
   return (
     <div className="list-container">

--- a/src/redux/books/book.js
+++ b/src/redux/books/book.js
@@ -1,23 +1,14 @@
-import { nanoid } from '@reduxjs/toolkit';
+import axios from 'axios';
 
-const defaultState = [
-  {
-    title: 'The Hunger Games',
-    author: 'Suzanne Collins',
-    id: nanoid(),
-  },
-  {
-    title: 'Dune',
-    author: 'Frank Herbert',
-    id: nanoid(),
-  },
-];
+const ADD = 'bookstore/books/ADD';
+const REMOVE = 'bookstore/books/REMOVE';
+const GET = 'bookstore/books/GET';
+const baseURL = 'https://us-central1-bookstore-api-e63c8.cloudfunctions.net/bookstoreApi/apps/uYBWkn6JQUP0zZxaMqGp/books';
 
-const ADD = 'booktore/books/ADD';
-const REMOVE = 'boostore/books/REMOVE';
-
-export default function booksReducer(state = defaultState, action = {}) {
+export default function booksReducer(state = [], action = {}) {
   switch (action.type) {
+    case GET:
+      return action.book;
     case ADD:
       return state.concat(action.book);
     case REMOVE:
@@ -26,6 +17,10 @@ export default function booksReducer(state = defaultState, action = {}) {
       return state;
   }
 }
+export const getBook = (book) => ({
+  type: GET,
+  book,
+});
 
 export function createBook(book) {
   return {
@@ -40,3 +35,36 @@ export function removeBook(book) {
     book,
   };
 }
+
+export const addNewBookApi = (book) => async (dispatch) => {
+  const {
+    title,
+    author,
+    id,
+    category,
+  } = book;
+  const newBook = {
+    item_id: id,
+    title,
+    author,
+    category,
+  };
+  await axios.post(baseURL, newBook);
+  dispatch(createBook(book));
+};
+
+export const getBooksToDisplayApi = () => async (dispatch) => {
+  const books = await axios.get(baseURL);
+  const objectOfBooks = Object.entries(books.data).map(([id, book]) => {
+    const { title, author, category } = book[0];
+    return {
+      id, title, author, category,
+    };
+  });
+  dispatch(getBook(objectOfBooks));
+};
+
+export const removeBookFromApi = (id) => async (dispatch) => {
+  await axios.delete(`${baseURL}/${id.id}`);
+  dispatch(removeBook(id));
+};

--- a/src/redux/categories/categories.js
+++ b/src/redux/categories/categories.js
@@ -1,4 +1,4 @@
-const CHECK = 'CHECK';
+const CHECK = 'bookstore/books/CHECK';
 
 export default function categoriesReducer(state = [], action = {}) {
   switch (action.type) {

--- a/src/redux/configureStore.js
+++ b/src/redux/configureStore.js
@@ -1,7 +1,14 @@
 import { configureStore } from '@reduxjs/toolkit';
+import thunk from 'redux-thunk';
 import booksReducer from './books/book';
 import categoriesReducer from './categories/categories';
 
-const store = configureStore({ reducer: { books: booksReducer, categories: categoriesReducer } });
+const store = configureStore({
+  reducer: {
+    books: booksReducer,
+    categories: categoriesReducer,
+  },
+  middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(thunk),
+});
 
 export default store;


### PR DESCRIPTION
## Refactor code to use the [Bookstore API](https://www.notion.so/Bookstore-API-51ea269061f849118c65c0a53e88a739) to add and remove books.
![](https://i0.wp.com/regroove.ca/wp-content/uploads/2018/07/react-redux-2.png)
- Used [`axios`](https://axios-http.com/docs/intro) for making API calls.
- Used `useEffect` to fetch book list from Bookstore API on Books page load.
- Added an action type `GET` that will pass API response to the `bookReducer` and update the state.
- Refactored `ADD` and `REMOVE` book features to persist your changes in the server. 